### PR TITLE
fix unnecessary time delay in get_version_list

### DIFF
--- a/minecraft_launcher_lib/utils.py
+++ b/minecraft_launcher_lib/utils.py
@@ -63,7 +63,7 @@ def get_version_list() -> list[MinecraftVersionInfo]:
     vlist: VersionListManifestJson = get_requests_response_cache("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json").json()
     returnlist: list[MinecraftVersionInfo] = []
     for i in vlist["versions"]:
-        returnlist.append({"id": i["id"], "type": i["type"], "releaseTime": datetime.fromisoformat(i["releaseTime"]), "complianceLevel": i["complianceLevel"]})
+        returnlist.append({"id": i["id"], "type": i["type"], "releaseTime": i["releaseTime"], "complianceLevel": i["complianceLevel"]})
     return returnlist
 
 


### PR DESCRIPTION
This function here:
```
def get_version_list() -> list[MinecraftVersionInfo]:
    """
    Returns all versions that Mojang offers to download

    Example:

    .. code:: python

        for version in minecraft_launcher_lib.utils.get_version_list():
            print(version["id"])
    """
    vlist: VersionListManifestJson = get_requests_response_cache("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json").json()
    returnlist: list[MinecraftVersionInfo] = []
    for i in vlist["versions"]:
        returnlist.append({"id": i["id"], "type": i["type"], "releaseTime": datetime.fromisoformat(i["releaseTime"]), "complianceLevel": i["complianceLevel"]})
    return returnlist


```
sorts through the whole list and changes iso format of releaseTime to a datetime.datetime function. This is unnecessary as if an user requires this, they may get the version THEN change the releastTime to datetime.datetime. 

This fixes a huge time delay that goes from 75.22 seconds to 0.26 seconds.

```
import minecraft_launcher_lib as mc
import time

start = time.time()

version_list = mc.utils.get_version_list()
print(version_list)

end = time.time()
print(f"Time taken: {end - start:.2f} seconds")
```
Output:

<img width="1518" height="280" alt="Screenshot 2025-07-31 at 6 18 01 PM" src="https://github.com/user-attachments/assets/3e1786d4-e7d4-4b50-9b33-86876e7648bf" />